### PR TITLE
made error handling on sign up page more user friendly

### DIFF
--- a/client/src/components/UI/SignUpForm.js
+++ b/client/src/components/UI/SignUpForm.js
@@ -62,7 +62,12 @@ class SignUpForm extends Component {
 
   handleChange(event) {
     this.setState({
-      [event.target.name]: event.target.value
+      [event.target.name]: event.target.value,
+      firstNameErr: undefined,
+      lastNameErr: undefined,
+      emailErr: undefined,
+      passwordErr: undefined,
+      confirmPasswordErr: undefined
     });
   }
 


### PR DESCRIPTION
Updated the error UI when entering information that does not confirm to the server's rules. Error messages will no disappear when user starts typing in any part of the form after the feedback is given to the user after a bad request. This should allow the user to receive additional error feedback if another bad request is given instead of the original error message remaining in place.